### PR TITLE
Fixing rubyStyle in RubyTextData

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,1 +1,0 @@
-include: package:pedantic/analysis_options.1.11.0.yaml

--- a/lib/src/build_ruby_span.dart
+++ b/lib/src/build_ruby_span.dart
@@ -31,7 +31,7 @@ WidgetSpan buildRubySpan(
 
   var effectiveRubyTextStyle = rubyStyle;
   if (style == null || style.inherit) {
-    effectiveRubyTextStyle = defaultRubyTextStyle.merge(style);
+    effectiveRubyTextStyle = defaultRubyTextStyle.merge(rubyStyle);
   }
   if (MediaQuery.boldTextOverride(context)) {
     effectiveRubyTextStyle = effectiveRubyTextStyle!


### PR DESCRIPTION
The parameter rubyStyle inside RubyTextData was not used to modify properly the style of the furigana.